### PR TITLE
Avoid warnings on lazy load

### DIFF
--- a/lib/Function/Return.pm
+++ b/lib/Function/Return.pm
@@ -168,7 +168,14 @@ sub _register_return_info {
     $metadata{$key} = $info;
 }
 
-sub CHECK {
+{
+    no warnings 'void'; # To avoid warnings 'Too late to run CHECK block'
+    sub CHECK {
+        check_sub();
+    }
+}
+
+sub check_sub {
     for my $decl (@DECLARATIONS) {
         my ($pkg, $sub, $types)  = @$decl{qw(pkg sub types)};
 
@@ -288,6 +295,10 @@ This interface is for power-user. Rather than using the C<< :Return >> attribute
 
     my $wrapped = Function::Return->wrap_sub($orig, [Str]);
     $wrapped->();
+
+=head3 Function::Return->check_sub()
+
+Generaly, it's unnecessary to call this method. If you loaded C<Function::Return> at runtime, then you should call C<check_sub> specifically.
 
 =head1 NOTE
 


### PR DESCRIPTION
Generaly, CHECK phase executes on last of compiling module. But I want to use this module as lazy-loaded. So a procs of CHECK should be able to being called from outside. And I've got rid of warnings 'Too late to run CHECK block'.

If we would have a way to avoid warnings from outside, we don't need `no warnings` in it. I think that it'd be better to have warnings. 