### PR TITLE
[DO NOT MERGE] support sugar

### DIFF
--- a/t/16_case_sugar.t
+++ b/t/16_case_sugar.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More;
+
+use lib 't/lib';
+
+use Sugar;
+
+sub foo :Return() {123}
+
+ok dies { foo() }
+
+done_testing;

--- a/t/16_case_sugar.t
+++ b/t/16_case_sugar.t
@@ -5,10 +5,9 @@ use Test::Fatal;
 
 use lib 't/lib';
 
-use Sugar;
+use Cola;
 
-sub foo :Return() {123}
-
-ok exception { foo() };
+lives_ok { Cola::drink() };
+dies_ok { Cola::invalid() };
 
 done_testing;

--- a/t/16_case_sugar.t
+++ b/t/16_case_sugar.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
-use Test::Fatal;
+use Test::Fatal qw(lives_ok dies_ok);
 
 use lib 't/lib';
 

--- a/t/16_case_sugar.t
+++ b/t/16_case_sugar.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Fatal;
 
 use lib 't/lib';
 
@@ -8,6 +9,6 @@ use Sugar;
 
 sub foo :Return() {123}
 
-ok dies { foo() }
+ok exception { foo() };
 
 done_testing;

--- a/t/lib/Cola.pm
+++ b/t/lib/Cola.pm
@@ -3,7 +3,6 @@ package Cola;
 use Sugar;
 
 sub drink :Return(Str) { 'good!' }
-
 sub invalid :Return() { 'bad..' }
 
 1;

--- a/t/lib/Cola.pm
+++ b/t/lib/Cola.pm
@@ -1,0 +1,9 @@
+package Cola;
+
+use Sugar;
+
+sub drink :Return(Str) { 'good!' }
+
+sub invalid :Return() { 'bad..' }
+
+1;

--- a/t/lib/Sugar.pm
+++ b/t/lib/Sugar.pm
@@ -1,13 +1,12 @@
 package Sugar;
 
+use Import::Into;
+
 sub import {
     my $caller = caller;
 
-    require Types::Standard;
-    Types::Standard->import('-types');
-
-    require Function::Return;
-    Function::Return->import(pkg => $caller);
+    Types::Standard->import::into($caller, '-types');
+    Function::Return->import::into($caller);
 }
 
 1;

--- a/t/lib/Sugar.pm
+++ b/t/lib/Sugar.pm
@@ -3,6 +3,9 @@ package Sugar;
 sub import {
     my $caller = caller;
 
+    require Types::Standard;
+    Types::Standard->import('-types');
+
     require Function::Return;
     Function::Return->import(pkg => $caller);
 }

--- a/t/lib/Sugar.pm
+++ b/t/lib/Sugar.pm
@@ -1,0 +1,10 @@
+package Sugar;
+
+sub import {
+    my $caller = caller;
+
+    require Function::Return;
+    Function::Return->import(pkg => $caller);
+}
+
+1;


### PR DESCRIPTION
This pull request is DEMO.

```perl
# Sugar.pm
package Sugar;

sub import {
    my $caller = caller;

    require Types::Standard;
    Types::Standard->import('-types');

    require Function::Return;
    Function::Return->import(pkg => $caller);
}

1;

# package main

use Sugar;

sub taste :Return(Str) { 'good' }
```