### PR TITLE
[DO NOT MERGE] Lazyload and export types fail case

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,7 @@ requires 'Function::Parameters', '2.000003';
 requires 'B::Hooks::EndOfScope', '0.23';
 requires 'namespace::autoclean';
 requires 'Types::Standard';
+requires 'Exporter';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'Scope::Upper';
 requires 'Function::Parameters', '2.000003';
 requires 'B::Hooks::EndOfScope', '0.23';
 requires 'namespace::autoclean';
+requires 'Types::Standard';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/t/16_lazyload_and_export_types.t
+++ b/t/16_lazyload_and_export_types.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use lib 't/lib';
+use Test::More;
+
+use Bear;
+
+is Bear::foo(), 'bar';
+
+done_testing;

--- a/t/16_lazyload_and_export_types.t
+++ b/t/16_lazyload_and_export_types.t
@@ -5,6 +5,8 @@ use Test::More;
 
 use Bear;
 
-is Bear::foo(), 'bar';
+is Bear::foo(), 'baz';
+
+is Bear::horse(), 'hogera';
 
 done_testing;

--- a/t/lib/Bear.pm
+++ b/t/lib/Bear.pm
@@ -1,0 +1,9 @@
+package Bear;
+use strict;
+use warnings;
+
+use Brown;
+
+sub foo :Return(Str) { 'bar' }
+
+1;

--- a/t/lib/Bear.pm
+++ b/t/lib/Bear.pm
@@ -2,8 +2,12 @@ package Bear;
 use strict;
 use warnings;
 
-use Brown;
+use Brown 'Bear';
 
-sub foo :Return(Str) { 'bar' }
+use Frog 'hoge';
+
+sub foo :Return(Str) { Frog->bar; }
+
+sub horse :Return(Str) { hoge(); }
 
 1;

--- a/t/lib/Brown.pm
+++ b/t/lib/Brown.pm
@@ -1,0 +1,16 @@
+package Brown;
+use strict;
+use warnings;
+
+require 'Function/Return.pm';
+Function::Return->import(pkg => 'Bear');
+
+require 'Types/Standard.pm';
+Types::Standard->import('Str');
+
+EXPORT_TYPE: {
+    no strict 'refs'; ## no critic
+    *{"Bear::Str"} = \&{"Brown::Str"};
+}
+
+1;

--- a/t/lib/Brown.pm
+++ b/t/lib/Brown.pm
@@ -2,15 +2,20 @@ package Brown;
 use strict;
 use warnings;
 
-require 'Function/Return.pm';
-Function::Return->import(pkg => 'Bear');
+sub import {
+    my $class  = shift;
+    my $target = shift;
 
-require 'Types/Standard.pm';
-Types::Standard->import('Str');
+    require 'Function/Return.pm';
+    Function::Return->import(pkg => $target);
 
-EXPORT_TYPE: {
-    no strict 'refs'; ## no critic
-    *{"Bear::Str"} = \&{"Brown::Str"};
+    require 'Types/Standard.pm';
+    Types::Standard->import('Str');
+
+    EXPORT_TYPE: {
+        no strict 'refs'; ## no critic
+        *{"${target}::Str"} = \&{"Brown::Str"};
+    }
 }
 
 1;

--- a/t/lib/Frog.pm
+++ b/t/lib/Frog.pm
@@ -1,0 +1,15 @@
+package Frog;
+use strict;
+use warnings;
+
+use Brown 'Frog';
+use parent qw/Exporter/;
+our @EXPORT_OK = qw/
+    hoge
+/;
+
+sub bar :Return(Str) { 'baz' }
+
+sub hoge :Return(Str) { 'hogera' }
+
+1;


### PR DESCRIPTION
This is demo PR. Do not merge this.

Something wrong. esp. EXPORT_OK? on `t/lib/Frog.pm`. I'm not sure yet though.

```
$ perl -Ilib -Ilocal/lib/perl5/ t/16_lazyload_and_export_types.t
Odd number of elements in hash assignment at lib/Function/Return.pm line 18.
ok 1
Undefined subroutine &Bear::hoge called at t/lib/Bear.pm line 11.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 255 just after 1.
```